### PR TITLE
Migrate to std.Io API and update Zig to 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ zig-cache
 zig-out
 *.pbn
 !puzzles/*.pbn
+zig-pkg
+mise.toml

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const devel = b.release_mode == .off;
+    const devel = optimize == .Debug;
     const app_id = "dev.ianjohnson.Nonograms";
 
     const gobject = b.dependency("gobject", .{});
@@ -44,6 +44,7 @@ pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "nonograms",
         .root_module = mod,
+        .use_llvm = true,
     });
     b.installArtifact(exe);
 
@@ -124,7 +125,9 @@ pub fn build(b: *std.Build) !void {
 
 fn readLinguas(b: *std.Build) []const []const u8 {
     const max_bytes = 16 * 1024; // 16KB
-    const raw = std.fs.cwd().readFileAlloc(b.allocator, b.pathFromRoot("po/LINGUAS"), max_bytes) catch |err|
+    var io = std.Io.Threaded.init(b.allocator, .{});
+    defer io.deinit();
+    const raw = std.Io.Dir.cwd().readFileAlloc(io.io(), b.pathFromRoot("po/LINGUAS"), b.allocator, std.Io.Limit.limited(max_bytes)) catch |err|
         std.debug.panic("failed to read LINGUAS: {}", .{err});
 
     var linguas: std.ArrayList([]const u8) = .empty;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .nonograms,
     .version = "0.0.0",
     .fingerprint = 0xe326218998fb7f12, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "data",
         "po",

--- a/src/Library.zig
+++ b/src/Library.zig
@@ -21,11 +21,11 @@ pub fn deinit(library: *Library) void {
     library.arena.deinit();
 }
 
-pub fn load(parent_allocator: Allocator) !Library {
+pub fn load(parent_allocator: Allocator, io: std.Io) !Library {
     const library_path = try libraryPathAlloc(parent_allocator);
     defer parent_allocator.free(library_path);
-    var library_dir = try std.fs.cwd().makeOpenPath(library_path, .{ .iterate = true });
-    defer library_dir.close();
+    var library_dir = try std.Io.Dir.cwd().createDirPathOpen(io, library_path, .{ .open_options = .{ .iterate = true } });
+    defer library_dir.close(io);
 
     var arena = ArenaAllocator.init(parent_allocator);
     errdefer arena.deinit();
@@ -33,15 +33,15 @@ pub fn load(parent_allocator: Allocator) !Library {
 
     var entries: std.ArrayList(Entry) = .empty;
     var library_dir_iter = library_dir.iterate();
-    while (try library_dir_iter.next()) |child| {
+    while (try library_dir_iter.next(io)) |child| {
         if (child.kind != .file or !mem.endsWith(u8, child.name, ".pbn")) {
             continue;
         }
 
-        const child_file = library_dir.openFile(child.name, .{}) catch continue;
-        defer child_file.close();
+        const child_file = library_dir.openFile(io, child.name, .{}) catch continue;
+        defer child_file.close(io);
         var buf: [1024]u8 = undefined;
-        var file_reader = child_file.reader(&buf);
+        var file_reader = child_file.reader(io, &buf);
         var diag: pbn.Diagnostics = .init(allocator);
         defer diag.deinit();
         var puzzle_set = pbn.PuzzleSet.parseReader(allocator, &file_reader.interface, &diag) catch continue;
@@ -55,14 +55,14 @@ pub fn load(parent_allocator: Allocator) !Library {
     return .{ .entries = try entries.toOwnedSlice(allocator), .arena = arena };
 }
 
-pub fn copyDefaultPuzzles(allocator: Allocator) !void {
+pub fn copyDefaultPuzzles(allocator: Allocator, io: std.Io) !void {
     const library_path = try libraryPathAlloc(allocator);
     defer allocator.free(library_path);
-    var library_dir = try std.fs.cwd().makeOpenPath(library_path, .{});
-    defer library_dir.close();
+    var library_dir = try std.Io.Dir.cwd().createDirPathOpen(io, library_path, .{});
+    defer library_dir.close(io);
 
     for (default_puzzles) |default_puzzle| {
-        try library_dir.writeFile(.{ .sub_path = default_puzzle.name, .data = default_puzzle.data });
+        try library_dir.writeFile(io, .{ .sub_path = default_puzzle.name, .data = default_puzzle.data });
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,13 +18,18 @@ const oom = @import("util.zig").oom;
 
 const package = "nonograms";
 
-pub fn main() !void {
+var global_io: std.Io = undefined;
+
+pub fn main(init: std.process.Init) !void {
+    global_io = init.io;
+
     intl.bindTextDomain(package, build_options.locale_dir ++ "");
     intl.bindTextDomainCodeset(package, "UTF-8");
     intl.setTextDomain(package);
 
     const app = Application.new();
-    const status = gio.Application.run(app.as(gio.Application), @intCast(std.os.argv.len), std.os.argv.ptr);
+    const args_vec = init.minimal.args.vector;
+    const status = gio.Application.run(app.as(gio.Application), @intCast(args_vec.len), @ptrCast(@constCast(args_vec.ptr)));
     std.process.exit(@intCast(status));
 }
 
@@ -168,13 +173,13 @@ const ApplicationWindow = extern struct {
         if (win.private().library) |*library| {
             library.deinit();
         }
-        var library = Library.load(c_allocator) catch {
+        var library = Library.load(c_allocator, global_io) catch {
             adw.ToastOverlay.addToast(win.private().toast_overlay, adw.Toast.new(intl.gettext("Failed to read library")));
             return;
         };
         if (library.entries.len == 0) {
-            if (Library.copyDefaultPuzzles(c_allocator)) {
-                library = Library.load(c_allocator) catch {
+            if (Library.copyDefaultPuzzles(c_allocator, global_io)) {
+                library = Library.load(c_allocator, global_io) catch {
                     adw.ToastOverlay.addToast(win.private().toast_overlay, adw.Toast.new(intl.gettext("Failed to read library")));
                     return;
                 };
@@ -369,7 +374,7 @@ const ApplicationWindow = extern struct {
         var rendered: std.Io.Writer.Allocating = .init(c_allocator);
         defer rendered.deinit();
         state.set.render(c_allocator, &rendered.writer) catch oom();
-        std.fs.cwd().writeFile(.{
+        std.Io.Dir.cwd().writeFile(global_io, .{
             .sub_path = path,
             .data = rendered.written(),
         }) catch return; // TODO: error handling

--- a/src/view.zig
+++ b/src/view.zig
@@ -205,7 +205,7 @@ pub const View = extern struct {
         _ = gtk.EventControllerKey.signals.key_released.connect(key, *View, &handleKeyReleased, view, .{});
         gtk.Widget.addController(view.as(gtk.Widget), key.as(gtk.EventController));
 
-        view.private().arena = ArenaAllocator.init(std.heap.raw_c_allocator);
+        view.private().arena = ArenaAllocator.init(std.heap.c_allocator);
 
         _ = ColorPicker.signals.color_selected.connect(view.private().color_picker, *View, &handleColorSelected, view, .{});
     }
@@ -628,7 +628,7 @@ pub const ColorPicker = extern struct {
         gtk.Widget.setLayoutManager(picker.as(gtk.Widget), gtk.BinLayout.new().as(gtk.LayoutManager));
 
         picker.private().buttons = &.{};
-        picker.private().arena = ArenaAllocator.init(std.heap.raw_c_allocator);
+        picker.private().arena = ArenaAllocator.init(std.heap.c_allocator);
     }
 
     fn dispose(picker: *ColorPicker) callconv(.c) void {


### PR DESCRIPTION
- Use the new std.Io threaded API and pass a global std.Io through main.zig
- Update Library.load and copyDefaultPuzzles to accept std.Io and use io-aware file/directory operations. 
- Change main to take std.process.Init and propagate args/io. (JuicyMain)
- Replace raw_c_allocator with c_allocator in views.
- Enable use_llvm for the executable ( Zig 0.16.x buildin compiler give .sframe link issues when linking with lib build with latest gcc)
- bump minimum_zig_version to 0.16.0.
- Add zig-pkg and mise.toml to .gitignore. 